### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,9 @@ setup(
     packages=['droiddepot'],
     classifiers=[
         'Programming Language :: Python :: 3',
-    ])
+    ],
+    install_requires=[
+        'bleak==0.20.2',
+        'pydBeacon==1.0.0',
+    ]
+)


### PR DESCRIPTION
Hello!
I installed this package from Pypi and noticed that I get an error that `dbeacon` package is not found.
Perhaps this is happening because `install_requires` is not specified in `setup.py`.
Therefore, I added `install_requires` so that when installing this package, the required packages, `bleak` and `pydBeacon`, are also installed.